### PR TITLE
Disable 'revert' buttons until user modifies entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,8 @@
                   data-loading-text="Deleting...">
                   Delete all milestones
                 </button>
-                <button id="revert-milestones-to-original" type="button" class="btn btn-outline-warning btn-block" disabled data-loading-text="Resetting...">
+                <button id="revert-milestones-to-original" type="button" class="btn btn-outline-warning btn-block"
+                  disabled data-loading-text="Resetting...">
                   Revert milestones to original
                 </button>
                 <button id="add-new-milestone-entry" type="button" class="btn btn-outline-success btn-block mb-3">

--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
                   data-loading-text="Deleting...">
                   Delete all labels
                 </button>
-                <button id="revert-labels-to-original" type="button" class="btn btn-outline-warning btn-block"
+                <button id="revert-labels-to-original" type="button" class="btn btn-outline-warning btn-block" disabled
                   data-loading-text="Resetting...">
                   Revert labels to original
                 </button>
@@ -215,8 +215,7 @@
                   data-loading-text="Deleting...">
                   Delete all milestones
                 </button>
-                <button id="revert-milestones-to-original" type="button" class="btn btn-outline-warning btn-block"
-                  data-loading-text="Resetting...">
+                <button id="revert-milestones-to-original" type="button" class="btn btn-outline-warning btn-block" disabled data-loading-text="Resetting...">
                   Revert milestones to original
                 </button>
                 <button id="add-new-milestone-entry" type="button" class="btn btn-outline-success btn-block mb-3">

--- a/js/app.js
+++ b/js/app.js
@@ -659,9 +659,24 @@ $(document).ready(function () {
   function checkIfAnyActionNeeded() {
     // returns true if any change has been made and activates or disactivates commit button accordingly
 
-    let isNeeded = $('.label-entry:not([action="none"])').length > 0 || $('.milestone-entry:not([action="none"])').length > 0;
+    let labelsModified = $('.label-entry:not([action="none"])').length > 0;
+    let milestonesModified = $('.milestone-entry:not([action="none"])').length > 0;
 
-    if (isNeeded) {
+    if (labelsModified) {
+      $('#revert-labels-to-original').removeAttr('disabled');
+    }
+    else {
+      $('#revert-labels-to-original').attr('disabled', true);
+    }
+
+    if (milestonesModified) {
+      $('#revert-milestones-to-original').removeAttr('disabled');
+    }
+    else {
+      $('#revert-milestones-to-original').attr('disabled', true);
+    }
+
+    if (labelsModified || milestonesModified) {
       $('#commit-to-target-repo').removeAttr('disabled');
       $('#commit-to-target-repo').removeClass('btn-outline-success')
       $('#commit-to-target-repo').addClass('btn-success');

--- a/js/app.js
+++ b/js/app.js
@@ -111,7 +111,7 @@ $(document).ready(function () {
         }
       }
     });
-    checkIfAnyActionNeeded();
+    checkIfAnyModifications();
   }
 
   function apiCallGetEntries(username, repo, kind, mode, callback) {
@@ -294,7 +294,7 @@ $(document).ready(function () {
         $entry.addClass('uncommitted');
       }
 
-      checkIfAnyActionNeeded();
+      checkIfAnyModifications();
       return;
     });
 
@@ -313,7 +313,7 @@ $(document).ready(function () {
 
       $(this).siblings('.recover-button').removeClass('hidden');
 
-      checkIfAnyActionNeeded();
+      checkIfAnyModifications();
       return;
     });
 
@@ -333,7 +333,7 @@ $(document).ready(function () {
         $entry.attr('action', 'update');
       }
 
-      checkIfAnyActionNeeded();
+      checkIfAnyModifications();
     });
 
     newElementEntry.find('.color-box').ColorPicker({
@@ -362,7 +362,7 @@ $(document).ready(function () {
         //   }
         //   // $(el).closest('label-entry').addClass('uncommitted');
         // }
-        // checkIfAnyActionNeeded();
+        // checkIfAnyModifications();
         return;
         //-----------------------------
       },
@@ -459,7 +459,7 @@ $(document).ready(function () {
         $entry.addClass('uncommitted');
       }
 
-      checkIfAnyActionNeeded();
+      checkIfAnyModifications();
       return;
     });
 
@@ -476,7 +476,7 @@ $(document).ready(function () {
 
       $(this).siblings('.recover-button').removeClass('hidden');
 
-      checkIfAnyActionNeeded();
+      checkIfAnyModifications();
       return;
     });
 
@@ -495,7 +495,7 @@ $(document).ready(function () {
         $entry.attr('action', 'update');
       }
 
-      checkIfAnyActionNeeded();
+      checkIfAnyModifications();
     });
 
     $('#form-milestones').prepend(newElementEntry);
@@ -563,7 +563,7 @@ $(document).ready(function () {
         $(this).attr('action', 'delete');
       }
     });
-    checkIfAnyActionNeeded();
+    checkIfAnyModifications();
   }
 
   $('#delete-all-labels').click(function () {
@@ -589,7 +589,7 @@ $(document).ready(function () {
       alert("Please enter the repo owner and the repo");
       $(this).button('reset');
     }
-    checkIfAnyActionNeeded();
+    checkIfAnyModifications();
   }
 
   $('#copy-labels-from').click(function () {
@@ -655,7 +655,7 @@ $(document).ready(function () {
     }
   }
 
-  function checkIfAnyActionNeeded() {
+  function checkIfAnyModifications() {
     // returns true if any change has been made and activates or disactivates commit button accordingly
 
     let labelsModified = $('.label-entry:not([action="none"])').length > 0;

--- a/js/app.js
+++ b/js/app.js
@@ -520,7 +520,7 @@ $(document).ready(function () {
       apiCallGetEntries(targetOwner, targetRepo, kind, 'list', () => {
         $(this).button('reset');
       });
-
+      $(`#revert-${kind}-to-original`).removeAttr('disabled');
       $('#' + kind + '-tab').tab('show');
     }
     else {

--- a/js/app.js
+++ b/js/app.js
@@ -520,7 +520,6 @@ $(document).ready(function () {
       apiCallGetEntries(targetOwner, targetRepo, kind, 'list', () => {
         $(this).button('reset');
       });
-      $(`#revert-${kind}-to-original`).removeAttr('disabled');
       $('#' + kind + '-tab').tab('show');
     }
     else {


### PR DESCRIPTION
# Fixes #90 

## Details
- The 'revert-`kind`-to original' buttons now start off disabled, as there shouldn't be anything to revert to at the outset.
- Only until the user lists labels or milestones will they enable the respective 'revert' buttons.

Whether or not this is the optimal solution to this issue is open for discussion.

## Preview
![disable revert buttons on load](https://user-images.githubusercontent.com/44086040/83088336-3f669b80-a048-11ea-805d-5d2c7b835e58.PNG)

## Checks

- [x] PR is concisely and descriptively titled 📑 and links to the original issue 🔗
- [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
- [x] Code is in uniquely-named feature branch and has no merge conflicts 📁
- [x] @mentions of the person or team responsible for reviewing proposed changes
- [x] Screenshots/GIFs are attached 📎 in case of UI updates
